### PR TITLE
improve luacheck linter

### DIFF
--- a/linters/luacheck.lua
+++ b/linters/luacheck.lua
@@ -7,19 +7,53 @@
 
 --- IMPLEMENTATION ---
 
+local common = require "core.common"
 local lintplus = require "plugins.lintplus"
+
+local config_options = { ",--config", ",--no-config," } --, ",--default-config" }
+local function contains_config_options(haystack)
+  for _, needle in ipairs(config_options) do
+    if nil ~= string.find(haystack, needle, 1, true) then
+      return true
+    end
+  end
+
+  return false
+end
+
+local function command(filename)
+  local def = {
+    "luacheck",
+    lintplus.args,
+    "--formatter",
+    "visual_studio",
+    lintplus.filename,
+  }
+  local luacheck_args = lintplus.config.luacheck_args or {}
+  local args_string = "," .. table.concat(luacheck_args, ",") .. ","
+  if contains_config_options(args_string) then
+    -- User has configured luacheck arguments dealing with config.
+    return lintplus.args_command(def, "luacheck_args")(filename)
+  end
+
+  -- We need to look for config file up the tree.
+  local path = common.dirname(filename)
+  local config_path
+  while path do
+    config_path = string.format("%s%s.luacheckrc", path, PATHSEP)
+    if system.get_file_info(config_path) then
+      table.insert(def, 2, string.format("--config %s", config_path))
+      break
+    end
+    path = common.dirname(path)
+  end
+  return lintplus.args_command(def, "luacheck_args")(filename)
+end
 
 lintplus.add("luacheck") {
   filename = "%.lua$",
   procedure = {
-    command = lintplus.args_command(
-      { "luacheck",
-        lintplus.args,
-        "--formatter",
-        "visual_studio",
-        lintplus.filename },
-      "luacheck_args"
-    ),
+    command = command,
     interpreter = lintplus.interpreter {
       warning = "(.-)%((%d+),(%d+)%) : warning .-: (.+)",
       error = "(.-)%((%d+),(%d+)%) : error .-: (.+)",

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
       "id": "lintplus",
       "name": "Lint+",
       "description": "An improved linting plugin.",
-      "version": "0.3",
+      "version": "0.4",
       "mod_version": "3",
       "tags": [
         "linter"


### PR DESCRIPTION
Search for config file (.luacheckrc) and if found
add it to the arguments passed to luacheck.
This makes it possible to open liteXL with the base directory containing several projects and still being able to lint them.
e.g. /projects/a/b/c and /projects/d/e and /projects/f a,d and f having their own .luacheckrc files
With these changes one can `litexl /porjects` and lint successfully with any files in projects,a,b,c,d,e and f. Previously one had to open litexl at a,bc,d,e and f but not at projects or higher up the tree (folders containing 'projects').